### PR TITLE
Added note regarding presto-cli vs presto

### DIFF
--- a/doc_source/emr-presto-considerations.md
+++ b/doc_source/emr-presto-considerations.md
@@ -2,6 +2,13 @@
 
 Consider the following differences and limitations when you run Presto on Amazon EMR\.
 
+## Presto Command Line Executable<a name="emr-presto-command-line-cli"></a>
+
+In EMR the Presto command line executable is presto-cli.
+```
+presto-cli --catalog hive
+```
+
 ## Some Presto Deployment Properties not Configurable<a name="emr-presto-deployment-config"></a>
 
 Depending on the version of Amazon EMR that you use, some Presto deployment configurations may not be available\. For more information about these properties, see [Deploying Presto](https://prestodb.io/docs/current/installation/deployment.html) in Presto Documentation\. The following table shows the configuration status for Presto `properties` files\.


### PR DESCRIPTION
The EMR Presto documentation references the Presto documentation, but nowhere mentions that to run Presto from the command line you need to use "presto-cli" vs. the normal "presto". I spent a good amount of time beating my head against this one and eventually opened a support request to get the answer. Someone familiar with Presto would probably know this or be able to discover it, but I'm coming from a Cloudera (Impala) background. This item would have saved me an hour.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
