### PR TITLE
update bash script to add multiple users

### DIFF
--- a/doc_source/emr-jupyterhub-pam-users.md
+++ b/doc_source/emr-jupyterhub-pam-users.md
@@ -53,7 +53,7 @@ do
    sudo docker exec jupyterhub useradd -m -s /bin/bash -N $i
    sudo docker exec jupyterhub bash -c "echo $i:$i | chpasswd"
    curl -XPOST --silent -k https://$(hostname):9443/hub/api/users/$i \
- -H "Authorization: token $TOKEN" | jq
+ -H "Authorization: token $TOKEN" | jq '.'
 done
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
The command `$ curl -XPOST --silent -k https://$(hostname):9443/hub/api/users/$i \
 -H "Authorization: token $TOKEN" | jq` in the script throws error when run as step. The users will be created successfully and will be able to login to JupyterHub but the step fails with exit code '2' due to jq command, because it expects an argument. 

*Description of changes:*
`$ curl -XPOST --silent -k https://$(hostname):9443/hub/api/users/$i \
 -H "Authorization: token $TOKEN" | jq '.'`
The argument '.' produces the formatted output without modifying it. It will resolve the issue and step will complete with exit code '0'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
