### PR TITLE
Update emr-jupyterhub-ldap-users.md

### DIFF
--- a/doc_source/emr-jupyterhub-ldap-users.md
+++ b/doc_source/emr-jupyterhub-ldap-users.md
@@ -97,11 +97,11 @@ And run the script:
 
 The JupyterHub docker container requires some user attributes in your Active Directory to find the user and create the appropriate entry in the database. 
 
-homeDirectory
-gidNumber
-uidNumber
-objectClass posixAccount
-uid
+homeDirectory - location where to the user's directory, usually /home/[user]
+gidNumber - a value higher than 60000 that is not already in use by another user, check your /etc/passwd file
+uidNumber - a value higher than 60000 that is not already in use by another user, check your /etc/group file
+objectClass - posixAccount
+uid - same as the user name
 
 ## Create User Home Directories<a name="emr-jupyterhub-ldap-directories"></a>
 

--- a/doc_source/emr-jupyterhub-ldap-users.md
+++ b/doc_source/emr-jupyterhub-ldap-users.md
@@ -93,6 +93,16 @@ And run the script:
 ./configure_ldap_client.sh
 ```
 
+## Add Attributes to Active Directory <a name="emr-jupyterhub-ldap-directories"></a>
+
+The JupyterHub docker container requires some user attributes in your Active Directory to find the user and create the appropriate entry in the database. 
+
+homeDirectory
+gidNumber
+uidNumber
+objectClass posixAccount
+uid
+
 ## Create User Home Directories<a name="emr-jupyterhub-ldap-directories"></a>
 
 JupyterHub needs home directories within the container to authenticate LDAP users and store instance data\. The following example demonstrates two users, *shirley* and *diego*, in the LDAP directory\.


### PR DESCRIPTION
Added a section with a list of attributes that must exist for the JupyterHub container PAM to find the user on Active Directory. They are called Unix attributes, and they are not created by default when a new user is created. I tested it with AWS managed AD and EMR emr-5.19.0. Without those attributes the JupyterHub is able to authenticate the user, but then generate an internal error (500) because the Linux PAM is not able to get the user information from LDAP, such as the user's home directory where JupyterHub stores the notebook data.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
