### PR TITLE
Fix ldap.user-bind-pattern 5.11.0 - 5.15.0

### DIFF
--- a/doc_source/emr-presto-ldap.md
+++ b/doc_source/emr-presto-ldap.md
@@ -101,7 +101,7 @@ The format of the `presto-config `configuration classification is slightly diffe
                 "Properties": {
                         "http-server.authentication.type": "LDAP",
                         "authentication.ldap.url": "ldaps://ip-xxx-xxx-xxx-xxx.ec2.internal:636",
-                        "ldap.user-bind-pattern": "uid=${USER},ou=admins,dc=ec2,dc=internal:uid=${USER},ou=datascientists,dc=ec2,dc=internal",
+                        "authentication.ldap.user-bind-pattern": "uid=${USER},ou=admins,dc=ec2,dc=internal:uid=${USER},ou=datascientists,dc=ec2,dc=internal",
                         "internal-communication.authentication.ldap.user": "presto",
                         "internal-communication.authentication.ldap.password": "123456"
                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed bind user pattern parameter for EMR 5.11.0 through 5.15.0.
Actual configuration doesn't work as `ldap.user-bind-pattern` is not recognized as a parameter and server.log throws `authentication.ldap.user-bind-pattern` is missing on EMR 5.11.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
