### PR TITLE
Fix broken links for Hudi

### DIFF
--- a/doc_source/emr-hudi-cli.md
+++ b/doc_source/emr-hudi-cli.md
@@ -1,6 +1,6 @@
 # Using the Hudi CLI<a name="emr-hudi-cli"></a>
 
-You can use the Hudi CLI to administer Hudi datasets to view information about commits, the filesystem, statistics, and more\. You can also use the CLI to manually perform compactions, schedule compactions, or cancel scheduled compactions\. For more information, see [Administering Hudi Pipelines](https://hudi.apache.org/admin_guide.html) in the Apache Hudi documentation\.
+You can use the Hudi CLI to administer Hudi datasets to view information about commits, the filesystem, statistics, and more\. You can also use the CLI to manually perform compactions, schedule compactions, or cancel scheduled compactions\. For more information, see [Administering Hudi Pipelines](https://hudi.apache.org/docs/admin_guide.html) in the Apache Hudi documentation\.
 
 **To start the Hudi CLI and connect to a dataset**
 

--- a/doc_source/emr-hudi-work-with-dataset.md
+++ b/doc_source/emr-hudi-work-with-dataset.md
@@ -1,6 +1,6 @@
 # Working With a Hudi Dataset<a name="emr-hudi-work-with-dataset"></a>
 
-Hudi supports currently supports inserting, updating, and deleting data in Hudi datasets through Spark\. For more information, see [Writing Hudi Datasets](https://hudi.apache.org/writing_data.html) in Apache Hudi documentation\.
+Hudi supports currently supports inserting, updating, and deleting data in Hudi datasets through Spark\. For more information, see [Writing Hudi Datasets](https://hudi.apache.org/docs/writing_data.html) in Apache Hudi documentation\.
 
 The following examples demonstrate how to launch the interactive Spark shell, use Spark submit, and use Amazon EMR Notebooks to work with Hudi on Amazon EMR\. You can also use the Hudi DeltaStreamer utility or other tools to write to a dataset\. Throughout this section, the examples demonstrate working with datasets using the Spark shell while connected to the master node using SSH as the default `hadoop` user\.
 


### PR DESCRIPTION
*Description of changes:*
The docs are available under  docs/* instead of directly under /.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
