### PR TITLE
FIX: replace unicode en dash with hyphen

### DIFF
--- a/doc_source/emr-jupyterhub-install-kernels-libs.md
+++ b/doc_source/emr-jupyterhub-install-kernels-libs.md
@@ -39,7 +39,7 @@ The script referenced in the following examples uses `pip` to install paramiko, 
 ```
 #!/bin/bash
 
-sudo python3 –m pip install boto3 paramiko nltk scipy scikit-learn pandas
+sudo python3 -m pip install boto3 paramiko nltk scipy scikit-learn pandas
 ```
 
 After you create the script, upload it to a location in Amazon S3, for example, `s3://mybucket/install-my-jupyter-libraries.sh`\. For more information, see [How do I Upload Files and Folders to an S3 Bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/upload-objects.html) in the *Amazon Simple Storage Service Console User Guide* so that you can use it in your bootstrap action or in your Python program\.


### PR DESCRIPTION
The example code uses the unicode en dash – instead of a hyphen -. Though they look the same, they are different characters and not using a hyphen in a bash script will error: `python: can't open file '–m': [Errno 2] No such file or directory`. This is an important little distinction because the code snippet in question has a little copy icon that erroneously copies the en dash to the clipboard for unsuspecting developers. Then they deploy that bootstrap script and, 10 minutes later after sifting through the instance logs, see this silly little mistake. Speaking on behalf of a friend, of course ;)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
