### PR TITLE
Fix Shell Commands in Iceberg Docs

### DIFF
--- a/doc_source/emr-iceberg-create-cluster.md
+++ b/doc_source/emr-iceberg-create-cluster.md
@@ -23,7 +23,7 @@ spark\-shell:
 
 ```
 spark-shell \
---conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"\
+--conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
 --conf "spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog" \
 --conf "spark.sql.catalog.spark_catalog.type=hive" \
 --conf "spark.sql.catalog.spark_catalog.warehouse=s3://>bucket</>prefix</"
@@ -33,7 +33,7 @@ spark\-submit:
 
 ```
 spark-submit \
---conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"\
+--conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
 --conf "spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog" \
 --conf "spark.sql.catalog.spark_catalog.type=hive" \
 --conf "spark.sql.catalog.spark_catalog.warehouse=s3://<bucket>/<prefix>/"


### PR DESCRIPTION
Shell commands are broken and throws error.

*Issue #, if available:*
N/A

*Description of changes:*
First line of the multi line shell commands were missing empty space before backward slash, so fixed that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
