### PR TITLE
Change gem name for v5190 to aws-sdk

### DIFF
--- a/doc_source/emr-5190-release.md
+++ b/doc_source/emr-5190-release.md
@@ -74,7 +74,7 @@ Last updated date: November 19, 2018
   + Modified the logic that limits the application master process to running on core nodes\. This functionality now uses the YARN node labels feature and properties in the `yarn-site` and `capacity-scheduler` configuration classifications\. For information, see [https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-instances-guidelines.html#emr-plan-spot-YARN.](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-instances-guidelines.html#emr-plan-spot-YARN.)
 + Default Amazon Linux AMI for Amazon EMR
   + `ruby18`, `php56`, and `gcc48` are no longer installed by default\. These can be installed if desired using `yum`\.
-  + The aws\-java\-sdk ruby gem is no longer installed by default\. It can be installed using `gem install aws-java-sdk`, if desired\. Specific components can also be installed\. For example, `gem install aws-java-sdk-s3`\.
+  + The aws\-sdk ruby gem is no longer installed by default\. It can be installed using `gem install aws-sdk`, if desired\. Specific components can also be installed\. For example, `gem install aws-sdk-s3`\.
 
 **Known issues**
 + **EMR Notebooks**—In some circumstances, with multiple notebook editors open, the notebook editor may appear unable to connect to the cluster\. If this happens, clear browser cookies and then reopen notebook editors\.


### PR DESCRIPTION
Gem `aws-java-sdk` doesn't exist.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
